### PR TITLE
Create release page automatically

### DIFF
--- a/.github/workflows/release_page.yml
+++ b/.github/workflows/release_page.yml
@@ -1,0 +1,24 @@
+name: Generate Release Page
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-it:
+    name: release-it
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install go for generating bin file
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install release-it
+        run: npm install -g release-it
+      - name: Run release-it
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: release-it --ci

--- a/.release-it.yml
+++ b/.release-it.yml
@@ -1,0 +1,12 @@
+hooks:
+  before:init: make build
+git:
+  commit: false
+  tag: true
+  push: true
+github:
+  release: true
+  assets:
+    - bin/gh-release-pr-generator
+npm:
+  publish: false


### PR DESCRIPTION
## Summary

Add the config file of GitHub Actions to enable to create a release page automatically.


## Ref

release-it ( https://github.com/release-it/release-it )
