### PR TITLE
Fix README: go version of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It fetches pull requests which merged into the development branch, and generates
 
 ## Installation
 
-Go 1.16+:
+Go 1.17+:
 
 ```sh
 go install github.com/nekonenene/gh-release-pr-generator@v1


### PR DESCRIPTION
# Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

I had updated go version in https://github.com/nekonenene/gh-release-pr-generator/pull/20, but README hasn't updated.

Update README: go version of requirements
